### PR TITLE
Remove api-version

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -3,7 +3,6 @@ version: 2.0.3
 name: EssentialsXYZ
 author: GlitchYT
 website: https://www.youtube.com/channel/UC5sdKs04x87MCQ7ZBTgKFwg
-api-version: 1.16
 commands:
     fly:
         description: allows fly for sender


### PR DESCRIPTION
You should consider removing api-version here if you want this plugin to work on 1.16 and below, if you were to try and load this on a 1.8 server it wouldn't run